### PR TITLE
Flutter ^3.0.0 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.0.0
+* Added support for Flutter ^3.0.0
+
 ## 2.2.1
 * Fixed a bug where enabling video polluted logs on Android.
 

--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ dependencies:
 ```dart
 // inside your main.dart
 
-// @dart = 2.12 
-// You can use other dart versions but we suggest 2.12 for better compile time checks.
+// @dart = 2.17.0 
+// You can use other dart versions but we suggest 2.17.0 for better compile time checks.
 import 'dart:async';
 import 'dart:io';
 import 'package:testfairy_flutter/testfairy_flutter.dart';
@@ -58,7 +58,7 @@ void main() {
 
 ### How to compile with latest Flutter and null-safe Dart?
 
-In order to use TestFairy with the latest **stable** Flutter channel, you must set the minimum version for the plugin as 2.1.0.
+In order to use TestFairy with the latest **stable** Flutter channel, you must set the minimum version for the plugin as 3.0.0.
 
 In order to use TestFairy with the latest **unstable** Flutter channel, you must clone this repo and use it as an offline dependency instead of the published version in pub.
 

--- a/example-dart1/ios/Flutter/AppFrameworkInfo.plist
+++ b/example-dart1/ios/Flutter/AppFrameworkInfo.plist
@@ -21,6 +21,6 @@
   <key>CFBundleVersion</key>
   <string>1.0</string>
   <key>MinimumOSVersion</key>
-  <string>8.0</string>
+  <string>9.0</string>
 </dict>
 </plist>

--- a/example-dart1/ios/Runner.xcodeproj/project.pbxproj
+++ b/example-dart1/ios/Runner.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 46;
+	objectVersion = 50;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -166,7 +166,7 @@
 		97C146E61CF9000F007C117D /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 1150;
+				LastUpgradeCheck = 1300;
 				ORGANIZATIONNAME = "The Chromium Authors";
 				TargetAttributes = {
 					97C146ED1CF9000F007C117D = {

--- a/example-dart1/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/example-dart1/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1150"
+   LastUpgradeVersion = "1300"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/example-dart1/lib/main.dart
+++ b/example-dart1/lib/main.dart
@@ -1,4 +1,4 @@
-// @dart = 2.9
+// @dart = 2.17
 import 'dart:async';
 import 'dart:core';
 import 'dart:io';
@@ -23,7 +23,7 @@ void main() {
   runZonedGuarded(() async {
     try {
       FlutterError.onError = (FlutterErrorDetails details) =>
-          TestFairy.logError(details?.exception ?? 'Unknown error');
+          TestFairy.logError(details.exception);
 
       // Call `await TestFairy.begin()` or any other setup code here.
 //      await TestFairy.setMaxSessionLength(60);
@@ -476,13 +476,13 @@ class _TestfairyExampleAppState extends State<TestfairyExampleApp> {
       await TestFairy.begin(APP_TOKEN);
       await Future<void>.delayed(const Duration(seconds: 2));
 
-      final String url = await TestFairy.getSessionUrl();
+      final String? url = await TestFairy.getSessionUrl();
 
       assert(url != null);
 
       print('Session Url: ' + (url ?? 'null'));
 
-      assert(url.contains('http'));
+      assert(url!.contains('http'));
 
       await Future<void>.delayed(const Duration(seconds: 2));
       await TestFairy.stop();
@@ -764,13 +764,13 @@ class _TestfairyExampleAppState extends State<TestfairyExampleApp> {
       await TestFairy.begin(APP_TOKEN);
       await Future<void>.delayed(const Duration(seconds: 2));
 
-      final String url = await TestFairy.getSessionUrl();
+      final String? url = await TestFairy.getSessionUrl();
 
       assert(url != null);
 
       print('Session Url: ' + (url ?? 'null'));
 
-      assert(url.contains('http'));
+      assert(url!.contains('http'));
 
       await TestFairy.stop();
     } catch (e) {

--- a/example-dart1/pubspec.yaml
+++ b/example-dart1/pubspec.yaml
@@ -1,11 +1,11 @@
 name: testfairy_flutter_example_dart1
 description: Demonstrates how to use the TestFairy plugin.
 publish_to: 'none'
-version: 2.2.1
+version: 3.0.0
 
 environment:
-  sdk: ">=2.1.0 <3.0.0"
-  flutter: ">=1.12.0 <2.0.0"
+  sdk: ">=2.17.0 <3.0.0"
+  flutter: ">=3.0.0"
 
 dependencies:
   flutter:
@@ -13,7 +13,7 @@ dependencies:
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
-  cupertino_icons: ^1.0.2
+  cupertino_icons: ^1.0.4
 
   # These exist for testing and should never be included by TestFairy SDK
   http: any

--- a/example/ios/Flutter/AppFrameworkInfo.plist
+++ b/example/ios/Flutter/AppFrameworkInfo.plist
@@ -21,6 +21,6 @@
   <key>CFBundleVersion</key>
   <string>1.0</string>
   <key>MinimumOSVersion</key>
-  <string>8.0</string>
+  <string>9.0</string>
 </dict>
 </plist>

--- a/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/example/ios/Runner.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 46;
+	objectVersion = 50;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -166,7 +166,7 @@
 		97C146E61CF9000F007C117D /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 1150;
+				LastUpgradeCheck = 1300;
 				ORGANIZATIONNAME = "The Chromium Authors";
 				TargetAttributes = {
 					97C146ED1CF9000F007C117D = {

--- a/example/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/example/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1150"
+   LastUpgradeVersion = "1300"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,4 +1,4 @@
-// @dart = 2.12
+// @dart = 2.17
 import 'dart:async';
 import 'dart:core';
 import 'dart:io';
@@ -64,6 +64,7 @@ class _TestfairyExampleAppState extends State<TestfairyExampleApp> {
   bool testing = false;
 
   GlobalKey hiddenWidgetKey = GlobalKey();
+
   // GlobalKey hiddenWidgetKey = GlobalKey(debugLabel: 'hideMe');
 
   @override

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -1,11 +1,11 @@
 name: testfairy_flutter_example
 description: Demonstrates how to use the TestFairy plugin.
 publish_to: 'none'
-version: 2.2.1
+version: 3.0.0
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=1.22.0"
+  sdk: ">=2.17.0 <3.0.0"
+  flutter: ">=3.0.0"
 
 dependencies:
   flutter:
@@ -13,7 +13,7 @@ dependencies:
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
-  cupertino_icons: ^1.0.2
+  cupertino_icons: ^1.0.4
 
   # These exist for testing and should never be included by TestFairy SDK
   http: any

--- a/lib/src/feedback_options.dart
+++ b/lib/src/feedback_options.dart
@@ -1,4 +1,4 @@
-// @dart = 2.12
+// @dart = 2.17
 part of testfairy;
 
 /// Feedback content returned after a feedback is sent.

--- a/lib/src/network_logging.dart
+++ b/lib/src/network_logging.dart
@@ -1,4 +1,4 @@
-// @dart = 2.12
+// @dart = 2.17
 // ignore_for_file: avoid_return_types_on_setters
 
 import 'dart:convert';
@@ -221,6 +221,19 @@ class _TestFairyHttpClient implements TestFairyHttpClient {
     return wrappedClient.putUrl(url).then((HttpClientRequest req) {
       return _TestFairyClientHttpRequest(req);
     });
+  }
+
+  @override
+  set connectionFactory(
+      Future<ConnectionTask<Socket>> Function(
+              Uri url, String? proxyHost, int? proxyPort)?
+          f) {
+    wrappedClient.connectionFactory = f;
+  }
+
+  @override
+  set keyLog(Function(String line)? callback) {
+    wrappedClient.keyLog = callback;
   }
 }
 

--- a/lib/src/testfairy_base.dart
+++ b/lib/src/testfairy_base.dart
@@ -1,4 +1,4 @@
-// @dart = 2.12
+// @dart = 2.17
 import 'dart:core';
 import 'dart:io';
 import 'dart:ui' as ui;
@@ -73,7 +73,7 @@ abstract class TestFairyBase {
   }
 
   static Future<List<Map<String, int>>> getHiddenRects() async {
-    await WidgetsBinding.instance!.endOfFrame;
+    await WidgetsBinding.instance.endOfFrame;
 
     final List<Map<String, int>> rects =
         hiddenWidgets.map(getRect).toList(growable: false);

--- a/lib/src/widget_detector.dart
+++ b/lib/src/widget_detector.dart
@@ -1,4 +1,4 @@
-// @dart = 2.12
+// @dart = 2.17
 import 'dart:async';
 import 'dart:convert';
 import 'dart:math';

--- a/lib/testfairy_flutter.dart
+++ b/lib/testfairy_flutter.dart
@@ -1,4 +1,4 @@
-// @dart = 2.12
+// @dart = 2.17
 
 library testfairy;
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,11 +1,11 @@
 name: testfairy_flutter
 description: TestFairy integration for Flutter, bundled with the native SDK
-version: 2.2.1
+version: 3.0.0
 homepage: https://testfairy.com
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=1.22.0"
+  sdk: ">=2.17.0 <3.0.0"
+  flutter: ">=3.0.0"
 
 dependencies:
   flutter:


### PR DESCRIPTION
Adds support for Flutter ^3.0.0

Changes the Dart SDK to `>=2.17.0 <3.0.0` and the Flutter SDK to `>=3.0.0`

Added a major version bump to `CHANGELOG.md` as this is not backwards compatible with older Flutter versions